### PR TITLE
Use compatible release version for plugin spec tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea/
 __pycache__/
+build/
+dist/
+insightconnect_integrations_validators.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='insightconnect_integrations_validators',
           'validators==0.12.1',
           'filetype==1.0.0',
           'pathlib==1.0.1',
-          'insightconnect-integrations-plugin-spec-tooling==1.0.0'
+          'insightconnect-integrations-plugin-spec-tooling~=1.0'
       ],
       entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Description
Updates setup.py to use the latest compatible release of the plugin spec tooling when installing.

Info: https://www.python.org/dev/peps/pep-0440/#compatible-release

