### PR TITLE
[DF-1865] - Syntax check added to makefile validator

### DIFF
--- a/rules/__init__.py
+++ b/rules/__init__.py
@@ -46,6 +46,6 @@ VALIDATORS = [
     LoggingValidator(),
     ProfanityValidator(),
     AcronymValidator(),
-    PrintValidator()
+    PrintValidator(),
     JSONValidator()
 ]

--- a/rules/makefile_validator.py
+++ b/rules/makefile_validator.py
@@ -1,6 +1,6 @@
 from .validator import KomandPluginValidator
 import os
-
+import subprocess
 
 class MakefileValidator(KomandPluginValidator):
 
@@ -67,8 +67,16 @@ class MakefileValidator(KomandPluginValidator):
                     'Makefile does not contain current validate target: '
                     '@test -x ../tools/bandit.sh && ../tools/bandit.sh || true')
 
+    @staticmethod
+    def validate_syntax(path_to_makefile):
+        result = subprocess.run(["make", "-n", "-C", path_to_makefile], capture_output=True)
+        err = result.stderr.decode("utf-8").strip()
+        if err is not "":
+            raise Exception(f'Makefile not properly formatted: {err}')
+
     def validate(self, spec):
         d = spec.directory
+        MakefileValidator.validate_syntax(d)
         for i in spec.raw_makefile().split('\n\n'):
             line = i.split('\n')
             if line[0].startswith('runner:'):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='insightconnect_integrations_validators',
-      version='1.1.0',
+      version='1.2.0',
       description='Validator tooling for InsightConnect integrations',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->
- added check for proper make syntax in makefile validator using `make -n`
- version bump

## Testing
<!-- Describe how this change was tested -->
- tested without changing anything to confirm it won't throw a false positive 
- tested after changing make file to use spaces instead of tabs to make sure validator finds error
<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
