### PR TITLE
[DF-2803] added validator to check for password type in connection

### DIFF
--- a/rules/__init__.py
+++ b/rules/__init__.py
@@ -25,6 +25,7 @@ from .acronym_validator import *
 from .print_validator import *
 from .json_validator import *
 from .exception_validator import *
+from .password_validator import *
 
 # The order of this list is the execution order of the validators.
 VALIDATORS = [
@@ -49,5 +50,6 @@ VALIDATORS = [
     AcronymValidator(),
     PrintValidator(),
     JSONValidator(),
-    ExceptionValidator()
+    ExceptionValidator(),
+    PasswordValidator()
 ]

--- a/rules/password_validator.py
+++ b/rules/password_validator.py
@@ -1,0 +1,15 @@
+from .validator import KomandPluginValidator
+
+
+class PasswordValidator(KomandPluginValidator):
+    def validate(self, plugin_spec):
+        connection = plugin_spec.spec_dictionary().get("connection")
+        if connection is None:
+            return
+        else:
+            for key in connection:
+                for sub_key in connection[key]:
+                    if sub_key == "type":
+                        if connection[key][sub_key] == "password":
+                            raise Exception("Remove credentials using type 'password' in plugin spec connection."
+                                            " Use 'credentials' types instead.")


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->
- checks to see if someone is using the `password` type in the connection in the plugin spec rather than a credentials type
https://issues.corp.rapid7.com/browse/DF-2803

## Testing
<!-- Describe how this change was tested -->
- changed nothing to see if validator would throw a false positive
- changed a plugin spec to have the password type in it to cause an error
![image](https://user-images.githubusercontent.com/52936618/64439015-1a379480-d097-11e9-9608-3446246cf465.png)

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
