### PR TITLE
[DF-3186] - added check for -x in version validator

### DIFF
--- a/rules/version_validator.py
+++ b/rules/version_validator.py
@@ -19,6 +19,8 @@ class VersionValidator(KomandPluginValidator):
             raise Exception('Version should be of semver format: x.x.x.')
         if version.startswith("0"):
             raise Exception('Version should begin at an initial version of 1.0.0 to comply with semver.')
+        if "-" in version:
+            raise Exception('Version should not contain dashes')
 
     @staticmethod
     def validate_version_quotes(spec):


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->
- do not want to release plugins with the format X.X.X-Y
- we do not want the -Y
https://issues.corp.rapid7.com/browse/DF-3186

## Testing
<!-- Describe how this change was tested -->
- confirmed validator worked normally with changes
- changed version to be 1.1.0-1 and it failed 
![image](https://user-images.githubusercontent.com/52936618/65057791-2944ff00-d941-11e9-9741-588ef0e758bd.png)

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
