### PR TITLE
[DF-3213] Acronym Validator Fix

### DIFF
--- a/rules/acronym_validator.py
+++ b/rules/acronym_validator.py
@@ -43,9 +43,9 @@ class AcronymValidator(KomandPluginValidator):
     def validate_subsection(section, bad):
         if type(section) is not dict:
             return
-        if 'description' in section:
+        if 'description' in section and type(section['description']) == str:
             AcronymValidator.validate_line(section['description'].split(), bad)
-        if 'title' in section:
+        if 'title' in section and type(section['title']) == str:
             AcronymValidator.validate_line(section['title'].split(), bad)
         for subsection in section:
             AcronymValidator.validate_subsection(section[subsection], bad)


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->
https://issues.corp.rapid7.com/browse/DF-3213
- @jmcadams-r7 discovered a bug where fields with the name "title" or "description" caused an error within the acronym validator

## Testing
<!-- Describe how this change was tested -->
- tested using `make validate` and the issue is now resolved
<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
