### PR TITLE
[DF-3241] - Output Validator Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ validate("/path/to/plugin/directory")
 ```
 
 ## Changelog
+* 1.1.2 - Fix for Acronym and Output validators
 * 1.1.1 - Removed breaking changes to Makefile validator
 * 1.1.0 - Add validator rules: Check for Help.md, profanity check, acronym capitalization check, 
 `print` usage check, JSON tests, exceptions, credentials, passwords | Updated rules: Makefiles, logging

--- a/rules/output_validator.py
+++ b/rules/output_validator.py
@@ -38,7 +38,7 @@ class OutputValidator(KomandPluginValidator):
     def validate(self, spec):
         schemas = OutputValidator.get_schemas(spec)
         for action in spec.actions():
-            path = os.path.join(spec.directory, f"test-output/{action}.json")
+            path = os.path.join(spec.directory, f".output/{action}.json")
             if os.path.exists(path):
                 with open(path, 'r') as output:  # if test output has been generated
                     self.validate_output(json.load(output), schemas[action], action)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='insightconnect_integrations_validators',
-      version='1.1.1',
+      version='1.1.2',
       description='Validator tooling for InsightConnect integrations',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->
https://issues.corp.rapid7.com/browse/DF-3241
- simple fix to update output validator to use `/.output` directory
- version bump to 1.1.2
- will do a release for this version
