### PR TITLE
[DF-3264] Line Number Error Messaging in Exception Validator

### DIFF
--- a/rules/exception_validator.py
+++ b/rules/exception_validator.py
@@ -17,13 +17,20 @@ class ExceptionValidator(KomandPluginValidator):
         pattern = "raise [A-Za-z]*"
         for line_num in range(len(text)):
             matches = re.findall(pattern, text[line_num])
-            violations = list(filter(lambda x: "raise PluginException" not in x
-                                               and "raise ConnectionTestException" not in x, matches))
+            violations = list(filter(lambda m: ExceptionValidator.violation_check(m), matches))
             if len(violations) > 0:
-                violating_lines.append(line_num)
+                violating_lines.append(str(line_num + 1))
 
         if len(violating_lines) > 0:
-            self._violating_files.append((os.path.relpath(joined_path, spec_dir), f"Line number(s): {violating_lines}"))
+            self._violating_files.append(f"{os.path.relpath(joined_path, spec_dir)}: {', '.join(violating_lines)}")
+
+    @staticmethod
+    def violation_check(match):
+        allowed = ["PluginException", "ConnectionTestException"]
+        for e in allowed:
+            if e in match:
+                return False
+        return True
 
     def validate(self, spec):
         d = spec.directory


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->
https://issues.corp.rapid7.com/browse/DF-3264
- added line numbers to the error messaging for exception validator

## Testing
<!-- Describe how this change was tested -->
```Validator ExceptionValidator failed!
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/icon_validator/validate.py", line 22, in validate
    v.validate(spec)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/rules/exception_validator.py", line 35, in validate
    raise Exception(f"Please use 'PluginException' or"
Exception: Please use 'PluginException' or 'ConnectionTestException' when raising an exception. The following files violated this rule: [('icon_google_web_risk/connection/connection.py', 'Line Number(s): [25]')]
```
<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
