### PR TITLE
DF-3432: Acronym Validator: SPAM is not an acronym

### DIFF
--- a/icon_validator/rules/acronym_validator.py
+++ b/icon_validator/rules/acronym_validator.py
@@ -20,7 +20,7 @@ class AcronymValidator(KomandPluginValidator):
         'OSSEC', 'OSI', 'OTRS',
         'PCI', 'PCAP', 'PDF', 'PEM', 'PHP', 'PKI', 'PID', 'PNG',
         'RAR', 'RBAC', 'REST', 'RFC', 'RPC', 'RPM', 'RPZ', 'RRS', 'RSA', 'RSS',
-        'SAML', 'SCCM', 'SDK', 'SHA', 'SHA1', 'SHASUM', 'SHA1SUM', 'SHA256', 'SHA512', 'SIEM', 'SLA', 'SMB', 'SMS', 'SMTP', 'SPAM', 'SPF', 'SQL', 'SNMP', 'SNS', 'SRV', 'SQS', 'SSH', 'SSDEEP', 'SSID', 'STIX', 'SSL', 'SUID',
+        'SAML', 'SCCM', 'SDK', 'SHA', 'SHA1', 'SHASUM', 'SHA1SUM', 'SHA256', 'SHA512', 'SIEM', 'SLA', 'SMB', 'SMS', 'SMTP', 'SPF', 'SQL', 'SNMP', 'SNS', 'SRV', 'SQS', 'SSH', 'SSDEEP', 'SSID', 'STIX', 'SSL', 'SUID',
         'TCP', 'TSV', 'TLD', 'TLP', 'TLS', 'TTL', 'TTP', 'TXT',
         'UBA', 'UDP', 'UI', 'UID', 'URI', 'URL', 'UTC', 'UUID', 'VPN',
         'VBA', 'VM', 'VPC', 'VNC', 'VT', 'VTI',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='insightconnect_integrations_validators',
-      version='1.1.6',
+      version='1.1.7',
       description='Validator tooling for InsightConnect integrations',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description

* `SPAM` is not an acronym and causing false positives in our code.