### PR TITLE
golang regeneration fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ to simulate the `--all` flag.
 
 ## Changelog
 
+* 2.1.0 - Update Golang RegenerationValidator
 * 2.0.2 - Update HelpValidator to fix error messaging
 * 2.0.1 - Update UseCaseValidator valid use case list
 * 2.0.0 - Update Help Validator to use new help format |

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='insightconnect_integrations_validators',
-      version='2.0.2',
+      version='2.1.0',
       description='Validator tooling for InsightConnect integrations',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes golang regeneration validator. Validation for go plugins used to not work, now it does! This output only fails because this branch isn't up to date with the hub changes
```
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator DockerValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator ExceptionValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Plugin failed validation!

----
[*] Total time elapsed: 2273.165ms
```