### PR TITLE
using argparse for icon-validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ to simulate the `--all` flag.
 
 ## Changelog
 
-* 2.1.7 - Using argparse module to handle arguments and provide -h option
+* 2.2.0 - Using argparse module to handle arguments and provide -h option
 * 2.1.6 - Fix issue where ID was an acronym
 * 2.1.5 - Fix issue where confidential validator was not checking against provided whitelist
 * 2.1.4 - Fix issue where confidential validator was triggering on remediated findings and updated formatting

--- a/icon_validator/__main__.py
+++ b/icon_validator/__main__.py
@@ -1,5 +1,4 @@
 import sys
-import logging
 import argparse
 import re
 import os

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='insightconnect_integrations_validators',
-      version='2.1.7',
+      version='2.2.0',
       description='Validator tooling for InsightConnect integrations',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description

Stop the icon-validator from running twice.  Added a help message, and will fail gracefully if presented with a path that does not exist.

https://issues.corp.rapid7.com/browse/DF-3604

## Testing
TOR-MBP-3824:icon-integrations-validators tslijboom$ icon-validate not-a-folder
[*] Path 'not-a-folder' does not exist
TOR-MBP-3824:icon-integrations-validators tslijboom$ icon-validate -h
usage: icon-validate [-h] [--all] [-a] path

Validate plugin code is ready for publishing to Rapid7 Hub

positional arguments:
  path        Path to find the plugin code

optional arguments:
  -h, --help  show this help message and exit
  --all       Run the Jenkins Validators as well
  -a          Run the Jenkins Validators as well

[*] insightconnect-integrations-validators 2.1.7

Running icon-validate <path> and icon-validate <path> -a work properly command line not included but it is the standard <something>Validator on every line.  With or without Jenkins items.
