### PR TITLE
Docker Exception prints helpful message and Docker Validator moved in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ to simulate the `--all` flag.
 
 ## Changelog
 
+* 2.6.8 - Docker Validator to run with -a command line argument | Helpful message on failure
 * 2.6.7 - Fix issue where OutputValidator was throwing error for plugins without any action
 * 2.6.6 - Fix issue where HelpInputOutputValidator was not extracting complete output section of an action or trigger
 * 2.6.5 - Update IconValidator to check for extension.png

--- a/icon_validator/rules/__init__.py
+++ b/icon_validator/rules/__init__.py
@@ -58,8 +58,7 @@ VALIDATORS = [
     JSONValidator(),
     OutputValidator(),
     RegenerationValidator(),
-    HelpInputOutputValidator(),
-    DockerValidator()
+    HelpInputOutputValidator()
 ]
 
 JENKINS_VALIDATORS = [
@@ -67,7 +66,8 @@ JENKINS_VALIDATORS = [
     CredentialsValidator(),
     PasswordValidator(),
     PrintValidator(),
-    ConfidentialValidator()
+    ConfidentialValidator(),
+    DockerValidator()
 ]
 
 WORKFLOW_VALIDATORS = [

--- a/icon_validator/rules/docker_validator.py
+++ b/icon_validator/rules/docker_validator.py
@@ -22,7 +22,9 @@ class DockerValidator(KomandPluginValidator):
                 try:
                     subprocess.check_call(build_image, stdout=fd, stderr=fd)
                 except subprocess.CalledProcessError as e:
-                    raise Exception('Docker image did not build successfully.') from e
+                    raise Exception('The plugin is either broken or the image might not be built.'
+                                    'Please try "icon-plugin build image" to rebuild the image.'
+                                    '"icon-plugin run -c bash" will open a bash shell on the build container.') from e
 
                 try:
                     subprocess.check_call(run_image, stdout=fd, stderr=fd)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='insightconnect_integrations_validators',
-      version='2.6.7',
+      version='2.6.8',
       description='Validator tooling for InsightConnect integrations',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
…to -a only

## Description
Docker Validator moved to -a exclusively and will print a more helpful message on failure.

https://issues.corp.rapid7.com/browse/DF-3713


## Testing

Screen shots:

<img width="978" alt="Screen Shot 2020-01-06 at 12 17 33 PM" src="https://user-images.githubusercontent.com/57681561/71836084-408b3200-3081-11ea-90c4-b2ae071d0899.png">

<img width="1680" alt="Screen Shot 2020-01-06 at 12 15 28 PM" src="https://user-images.githubusercontent.com/57681561/71836098-45e87c80-3081-11ea-9efc-4f2af499c4bd.png">

<img width="524" alt="Screen Shot 2020-01-06 at 12 16 13 PM" src="https://user-images.githubusercontent.com/57681561/71836367-d3c46780-3081-11ea-94a9-de856d3a31e8.png">
