### PR TITLE
HelpInputOutputValidator error messages and bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ to simulate the `--all` flag.
 
 ## Changelog
 
+* 2.6.9 - Update HelpInputOutputValidator to fix error messaging |
+Fix issue with HelpInputOutputValidator when help.md has action and trigger with same name
 * 2.6.8 - Docker Validator to run with -a command line argument | Helpful message on failure
 * 2.6.7 - Fix issue where OutputValidator was throwing error for plugins without any action
 * 2.6.6 - Fix issue where HelpInputOutputValidator was not extracting complete output section of an action or trigger

--- a/icon_validator/rules/help_input_output_validator.py
+++ b/icon_validator/rules/help_input_output_validator.py
@@ -10,29 +10,45 @@ class HelpInputOutputValidator(KomandPluginValidator):
     action_missing = 0
 
     @staticmethod
-    def validate_input(action_title: str, action_input: list):
-        regex = r"#### " + action_title + "\n.*?#+ Output"
+    def validate_input(action_title: str, action_input: list, process_type: str):
+        regex = r"### " + process_type.capitalize() + ".*?#### " + action_title + "\n.*?#+ Output"
+        if process_type == "actions":
+            regex = regex + ".*?### Triggers"
+
         action_input_section = re.findall(regex, HelpInputOutputValidator.raw_help, re.DOTALL)
 
         if not action_input_section:
-            print(f"{YELLOW}Action/Trigger \"{action_title}\" could be missing or title is incorrect in help.md{RESET_ALL}")
+            print(f"{YELLOW}{process_type[:-1].capitalize()} \"{action_title}\" could be missing or title is incorrect in help.md{RESET_ALL}")
             HelpInputOutputValidator.violated = 1
             HelpInputOutputValidator.action_missing = 1
             return
+
+        regex = r"#### " + action_title + "\n.*?#+ Output"
+        action_input_section = re.findall(regex, action_input_section[0], re.DOTALL)
 
         for input_fields in action_input:
             if input_fields not in action_input_section[0]:
                 HelpInputOutputValidator.violations.append(input_fields)
 
     @staticmethod
-    def validate_output(action_title: str, action_output: list):
-        regex = r"#### " + action_title + "\n.*?#+ Output\n\n.*?\n\n"
-        action_help_section = re.findall(regex, HelpInputOutputValidator.raw_help, re.DOTALL)
+    def validate_output(action_title: str, action_output: list, process_type: str):
+        regex = r"### " + process_type.capitalize() + ".*?#### " + action_title + "\n.*?#+ Output\n\n.*?\n\n"
+        if process_type == "actions":
+            regex = regex + ".*?### Trigger"
 
-        if "This action does not contain any outputs." not in action_help_section[0]:
+        action_help_section_temp = re.findall(regex, HelpInputOutputValidator.raw_help, re.DOTALL)
+        regex = r"#### " + action_title + "\n.*?#+ Output\n\n.*?\n\n"
+        action_help_section = re.findall(regex, action_help_section_temp[0], re.DOTALL)
+
+        if "This " + process_type[:-1] + " does not contain any outputs." not in action_help_section[0]:
+            regex = r"### " + process_type.capitalize() + ".*?#### " + action_title + "\n.*?#+ Output\n\n.*?" + re.escape("|Name|Type|Required|Description|") + ".*?\n\n"
+            if process_type == "actions":
+                regex = regex + ".*?### Triggers"
+
+            action_help_section_temp = re.findall(regex, HelpInputOutputValidator.raw_help, re.DOTALL)
             regex = r"#### " + action_title + "\n.*?#+ Output\n\n.*?" + re.escape("|Name|Type|Required|Description|") + ".*?\n\n"
-            action_help_section = re.findall(regex, HelpInputOutputValidator.raw_help, re.DOTALL)
-            action_output_section = re.findall(r'#+ Output\n\n.*?' + re.escape("|Name|Type|Required|Description|") + ".*?\n\n", action_help_section[0], re.DOTALL)
+            action_output_section_temp = re.findall(regex, action_help_section_temp[0], re.DOTALL)
+            action_output_section = re.findall(r'#+ Output\n\n.*?' + re.escape("|Name|Type|Required|Description|") + ".*?\n\n", action_output_section_temp[0], re.DOTALL)
         else:
             action_output_section = re.findall(r"#+ Output\n\n.*?\n\n", action_help_section[0], re.DOTALL)
 
@@ -68,34 +84,35 @@ class HelpInputOutputValidator(KomandPluginValidator):
     def validate(self, spec):
         HelpInputOutputValidator.raw_help = spec.raw_help()
         raw_spec_yaml = spec.spec_dictionary()
-        actions = raw_spec_yaml.get('actions', {})
-        actions.update(raw_spec_yaml.get('triggers', {}))
+        process_type = ["actions", "triggers"]
 
-        for key, value in actions.items():
-            action_name = actions[key].get('title')
-            input_section = actions[key].get('input')
-            output_section = actions[key].get('output')
-            HelpInputOutputValidator.action_missing = 0
+        for p_type in process_type:
+            actions = raw_spec_yaml.get(p_type, {})
+            for key, value in actions.items():
+                action_name = actions[key].get('title')
+                input_section = actions[key].get('input')
+                output_section = actions[key].get('output')
+                HelpInputOutputValidator.action_missing = 0
 
-            # Action with no input in spec file will skip input validation
-            if input_section:
-                action_input_fields = HelpInputOutputValidator.get_spec_input(input_section)
-                HelpInputOutputValidator.validate_input(action_name, action_input_fields)
+                # Action with no input in spec file will skip input validation
+                if input_section:
+                    action_input_fields = HelpInputOutputValidator.get_spec_input(input_section)
+                    HelpInputOutputValidator.validate_input(action_name, action_input_fields, p_type)
 
-                if HelpInputOutputValidator.violations:
-                    print(f'{YELLOW}Input violations: Action/Trigger -> \"{action_name}\": Missing {HelpInputOutputValidator.violations} in help.md{RESET_ALL}')
-                    HelpInputOutputValidator.violations = []
-                    HelpInputOutputValidator.violated = 1
+                    if HelpInputOutputValidator.violations:
+                        print(f'{YELLOW}Input violations: {p_type[:-1].capitalize()} -> \"{action_name}\": Missing {HelpInputOutputValidator.violations} in help.md{RESET_ALL}')
+                        HelpInputOutputValidator.violations = []
+                        HelpInputOutputValidator.violated = 1
 
-            # Actions with no output in spec file will skip output validation. Also, skip output validation for actions not found in help.md
-            if output_section and not HelpInputOutputValidator.action_missing:
-                action_output_fields = HelpInputOutputValidator.get_spec_output(output_section)
-                HelpInputOutputValidator.validate_output(action_name, action_output_fields)
+                # Actions with no output in spec file will skip output validation. Also, skip output validation for actions not found in help.md
+                if output_section and not HelpInputOutputValidator.action_missing:
+                    action_output_fields = HelpInputOutputValidator.get_spec_output(output_section)
+                    HelpInputOutputValidator.validate_output(action_name, action_output_fields, p_type)
 
-                if HelpInputOutputValidator.violations:
-                    print(f'{YELLOW}Output violations: Action/Trigger -> \"{action_name}\": Missing {HelpInputOutputValidator.violations} in help.md{RESET_ALL}')
-                    HelpInputOutputValidator.violations = []
-                    HelpInputOutputValidator.violated = 1
+                    if HelpInputOutputValidator.violations:
+                        print(f'{YELLOW}Output violations: {p_type[:-1].capitalize()}-> \"{action_name}\": Missing {HelpInputOutputValidator.violations} in help.md{RESET_ALL}')
+                        HelpInputOutputValidator.violations = []
+                        HelpInputOutputValidator.violated = 1
 
         if HelpInputOutputValidator.violated:
             raise Exception("Help.md is not in sync with plugin.spec.yaml. Please check and rectify above violations")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='insightconnect_integrations_validators',
-      version='2.6.8',
+      version='2.6.9',
       description='Validator tooling for InsightConnect integrations',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description
- Update HelpInputOutputValidator to fix error messaging
- Fix issue with HelpInputOutputValidator when help.md has action and trigger with same name
## Testing
Refer below validator output with error messages specifying if the mismatch is with actions or trigger. 

`[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Colors.mk ../tools/Makefiles/Helpers.mk
--
[*] Running validators
You are using pip version 19.0.3, however version 19.3.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
**Input violations: Action -> "Process String": Missing ['|expression|string|None|True|Awk expression e.g. [pattern] { action }|None|', '|text|string|None|True|String to process|None|'] in help.md
Output violations: Action-> "Process String": Missing ['|out|string|False|Processed string|'] in help.md
Input violations: Action -> "Process File": Missing ['|expression|string|None|True|Awk expression e.g. [pattern] { action }|None|', '|data|bytes|None|True|File to process|None|'] in help.md
Output violations: Action-> "Process File": Missing ['|out|string|False|Processed string|'] in help.md
Input violations: Trigger -> "Process File": Missing ['|expression|string|None|True|Awk expression e.g. [pattern] { action }|None|', '|data|bytes|None|True|File to process|None|'] in help.md
Output violations: Trigger-> "Process File": Missing ['|out|string|False|Processed string|'] in help.md
Input violations: Trigger -> "Process String": Missing ['|expression|string|None|True|Awk expression e.g. [pattern] { action }|None|', '|text|string|None|True|String to process|None|'] in help.md
Output violations: Trigger-> "Process String": Missing ['|out|string|False|Processed string|'] in help.md**
Validator HelpInputOutputValidator failed!
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/icon_validator/validate.py", line 29, in validate
    v.validate(spec)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/icon_validator/rules/help_input_output_validator.py", line 118, in validate
    raise Exception("Help.md is not in sync with plugin.spec.yaml. Please check and rectify above violations")
Exception: Help.md is not in sync with plugin.spec.yaml. Please check and rectify above violations
[*]Plugin failed validation!`