### PR TITLE
updated URL validator to better open files. small bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ to simulate the `--all` flag.
 
 ## Changelog
 
+* 2.8.1 - Bug fix for URLValidator when opening files
 * 2.8.0 - Update ChangelogValidator to validate plugin's version history with latest version number |
 Update HelpInputOutputValidator error messaging
 * 2.7.0 - Add URL Validator

--- a/icon_validator/rules/url_validator.py
+++ b/icon_validator/rules/url_validator.py
@@ -1,4 +1,5 @@
 import http.client
+import os
 import urllib
 import urllib.request
 from typing import List
@@ -62,18 +63,21 @@ class URLValidator(KomandPluginValidator):
         return return_list
 
     def validate(self, spec):
-        raw_spec_contents = spec.raw_spec()
-        spec_file_bad_urls = self.inspect_file_for_urls_and_test_them(raw_spec_contents)
-        if len(spec_file_bad_urls) > 0:
-            self._violating_files_to_urls_map[spec.spec_file_name] = spec_file_bad_urls
+        specfile = spec.directory + '/' + spec.spec_file_name
+        if os.path.exists(specfile):
+            raw_spec_contents = spec.raw_spec()
+            spec_file_bad_urls = self.inspect_file_for_urls_and_test_them(raw_spec_contents)
+            if len(spec_file_bad_urls) > 0:
+                self._violating_files_to_urls_map[specfile] = spec_file_bad_urls
 
         helpfile = spec.directory + '/help.md'
-        help_file_contents = ''
-        with open(helpfile) as h:
-            help_file_contents = h.read()
-        help_file_bad_urls = self.inspect_file_for_urls_and_test_them(help_file_contents)
-        if len(help_file_bad_urls) > 0:
-            self._violating_files_to_urls_map['help.md'] = help_file_bad_urls
+        if os.path.exists(helpfile):
+            help_file_contents = ''
+            with open(helpfile) as h:
+                help_file_contents = h.read()
+                help_file_bad_urls = self.inspect_file_for_urls_and_test_them(help_file_contents)
+                if len(help_file_bad_urls) > 0:
+                    self._violating_files_to_urls_map[helpfile] = help_file_bad_urls
 
         if len(self._violating_files_to_urls_map) > 0:
             header_printed = False
@@ -93,4 +97,5 @@ class URLValidator(KomandPluginValidator):
                                                'Verify they are publicly accessible and if not, update with a working URL'))
                             print(header)
                             header_printed = True
-                        print(f'{YELLOW}violation: {violating_file}[{actual_line_number_in_file}]: ' + str(url))
+                        file_name = os.path.basename(violating_file)
+                        print(f'{YELLOW}violation: {file_name}[{actual_line_number_in_file}]: ' + str(url))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='insightconnect_integrations_validators',
-      version='2.8.0',
+      version='2.8.1',
       description='Validator tooling for InsightConnect integrations',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description

Jenkins checks are failing the URL validator because it was failing to open files.  It was always working locally so this was not discovered when URL Validator was first built.  

More explicit paths are used when opening files, not the basename()

## Testing

Still works fine locally, it is the Jenkins testing that was failing.  I do not know how to test that before putting up the PR.


TOR-MBP-3824:anomali_threatstream tslijboom$ icon-validate . -a
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL
violation: plugin.spec.yaml[232]: https://ts.example.com
[*] Plugin successfully validated!

----
[*] Total time elapsed: 10141.743999999999ms