### PR TITLE
Add new example input to whitelist in SpecPropertiesValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ to simulate the `--all` flag.
 
 ## Changelog
 
+* 2.19.0 - Add new `example` input to whitelist in SpecPropertiesValidator
 * 2.18.0 - Add .icon file validator
 * 2.17.2 - Fix to remove some common words from the profanity validator
 * 2.17.1 - Fix broken package import

--- a/icon_validator/rules/plugin_validators/spec_properties_validator.py
+++ b/icon_validator/rules/plugin_validators/spec_properties_validator.py
@@ -19,7 +19,8 @@ class SpecPropertiesValidator(KomandPluginValidator):
         "required",
         "default",
         "enum",
-        "order"
+        "order",
+        "example"
     }
 
     def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name="insightconnect_integrations_validators",
-      version="2.18.0",
+      version="2.19.0",
       description="Validator tooling for InsightConnect integrations",
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description

* Add new `example` in spec to whitelist for SpecPropertiesValidator
* This new key is a place where we can store user examples for representation in docs and the product UI