### PR TITLE
install requirements.txt on all builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,4 +16,5 @@ jobs:
     - name: Build and run
       run: |
         pip install .
+        pip install -r requirements.txt
         icon-validate --version

--- a/.github/workflows/pypi_prod_publish.yml
+++ b/.github/workflows/pypi_prod_publish.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+        pip install -r requirements.txt
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_PROD_USERNAME }}

--- a/.github/workflows/pypi_test_publish.yml
+++ b/.github/workflows/pypi_test_publish.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+        pip install -r requirements.txt
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_TEST_USERNAME }}


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->

- All builds should install packages from requirements.txt


<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
