### PR TITLE
Revert install requirements.txt for pypi publish

### DIFF
--- a/.github/workflows/pypi_prod_publish.yml
+++ b/.github/workflows/pypi_prod_publish.yml
@@ -17,7 +17,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-        pip install -r requirements.txt
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_PROD_USERNAME }}

--- a/.github/workflows/pypi_test_publish.yml
+++ b/.github/workflows/pypi_test_publish.yml
@@ -18,7 +18,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-        pip install -r requirements.txt
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_TEST_USERNAME }}


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
This change reverts the change to the pypi publish workflow that attempted to install packages from requirements.txt


<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
