### PR TITLE
Update pypi_prod_publish.yml

### DIFF
--- a/.github/workflows/pypi_prod_publish.yml
+++ b/.github/workflows/pypi_prod_publish.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Description
This forces the GitHub action to publish to pypi to use python3.8 instead of python3.9
