### PR TITLE
SOAR-4525: Remove validation on matching workflow.spec.yaml & .icon descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ be on your way to contributing!
 
 ## Changelog
 
+* 2.29.0 - Remove Workflow Description Validator to validate that the workflow `description` in workflow .icon file matches the description in workflow.spec.yaml
 * 2.28.0 - Add Encoding Validators to look for problematic characters | Update Workflow Description Validator to validate existence of `description` in workflow .icon file | Update Workflow Description Validator to validate that the workflow `description` in workflow .icon file matches the description in workflow.spec.yaml | Update `title_validation_list` | Change error message in `title_validator` for capitalized word when it should not
 * 2.27.0 - Add CloudReadyConnectionCredentialToken Validator
 * 2.26.0 - Add Example Input Validator to validate if example field exist in plugin.spec | Remove Mitre from AcronymValidator

--- a/icon_validator/rules/workflow_validators/workflow_description_validator.py
+++ b/icon_validator/rules/workflow_validators/workflow_description_validator.py
@@ -26,12 +26,6 @@ class WorkflowDescriptionValidator(KomandPluginValidator):
             raise ValidationException("Workflow description in workflow .icon file can not be blank")
 
     @staticmethod
-    def validate_icon_description_match_callback(spec, workflow_version):
-        spec_description = spec.spec_dictionary()["description"]
-        if workflow_version.get("description") != spec_description:
-            raise ValidationException("Workflow description mismatch between workflow.spec.yaml and workflow .icon file")
-
-    @staticmethod
     def validate_icon_description_exists(spec):
         WorkflowDescriptionValidator.walk_icon_workflows(
             spec,
@@ -40,13 +34,6 @@ class WorkflowDescriptionValidator(KomandPluginValidator):
         WorkflowDescriptionValidator.walk_icon_workflows(
             spec,
             WorkflowDescriptionValidator.validate_icon_description_empty_callback
-        )
-
-    @staticmethod
-    def validate_icon_description_match_spec(spec):
-        WorkflowDescriptionValidator.walk_icon_workflows(
-            spec,
-            WorkflowDescriptionValidator.validate_icon_description_match_callback
         )
 
     @staticmethod
@@ -71,7 +58,6 @@ class WorkflowDescriptionValidator(KomandPluginValidator):
         WorkflowDescriptionValidator.validate_workflow_description_exists(spec)
         WorkflowDescriptionValidator.validate_workflow_description_punctuation(spec.spec_dictionary()["description"])
         WorkflowDescriptionValidator.validate_icon_description_exists(spec)
-        WorkflowDescriptionValidator.validate_icon_description_match_spec(spec)
 
     @staticmethod
     def read_icon(spec, file_name):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="insightconnect_integrations_validators",
-    version="2.28.0",
+    version="2.29.0",
     description="Validator tooling for InsightConnect integrations",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/unit_test/test_validate_workflow.py
+++ b/unit_test/test_validate_workflow.py
@@ -190,9 +190,3 @@ class TestWorkflowValidate(unittest.TestCase):
         file_to_test = "workflow.spec.yaml"
         result = validate(directory_to_test, file_to_test, False, True, [WorkflowDescriptionValidator()])
         self.assertEqual(result, 1)
-
-    def test_icon_validator_description_not_match_descriptions_should_fail(self):
-        directory_to_test = "workflow_examples/description_validator_bad"
-        file_to_test = "workflow.spec.yaml"
-        result = validate(directory_to_test, file_to_test, False, True, [WorkflowDescriptionValidator()])
-        self.assertEqual(result, 1)


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->

- removes validation check that required the .icon file and workflow.spec.yaml have equal descriptions

<!-- Add JIRA link if applicable -->
https://issues.corp.rapid7.com/browse/SOAR-4525
## Testing
<!-- Describe how this change was tested -->
Updated unit tests
<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
