### PR TITLE
Exit with correct return codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ be on your way to contributing!
 
 ## Changelog
 
+* 2.40.1 - Exit with proper return codes when ran independently via CLI 
 * 2.40.0 - Add PythonScriptUseValidator for workflows
 * 2.39.0 - Add HelpExampleValidator | Improve EncodingValidator by printing all forbidden characters at one time
 * 2.38.0 - Remove LoggingValidator | Update dependency versions

--- a/icon_validator/__main__.py
+++ b/icon_validator/__main__.py
@@ -46,10 +46,13 @@ def main():
 
     if extension == "plugin" and the_arguments.run_all_validators:
         print(f"{BULLET_OK} Validating {extension} with all validators at {path}\n")
-        validate(directory=path, run_all=True)
+        return_code = validate(directory=path, run_all=True)
     else:
         print(f"{BULLET_OK} Validating {extension} at {path}\n")
-        validate(directory=path, spec_file_name=spec_file_name)
+        return_code = validate(directory=path, spec_file_name=spec_file_name)
+
+    sys.exit(return_code)
+
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="insightconnect_integrations_validators",
-    version="2.40.0",
+    version="2.40.1",
     description="Validator tooling for InsightConnect integrations",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description
Exits with the correct return codes when ran independently (not when used as a library) via CLI.

## Testing
Tested locally 
<img width="1185" alt="Screen Shot 2021-08-30 at 4 09 53 PM" src="https://user-images.githubusercontent.com/32079048/131406000-337bb862-119c-4469-81b6-6df0937164a1.png">

