### PR TITLE
fixed multiple issues with version bump validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ be on your way to contributing!
 
 ## Changelog
 
+* 2.43.2 - Fixed breaking change that caused VersionBumpValidator to not get remote changes, made code safer
 * 2.43.1 - Add GitPython dependency for using VersionBumpValidator
 * 2.43.0 - Add VersionBumpValidator to check if a major or minor version increment is needed
 * 2.42.0 - Add in WorkflowScreenshotValidator to check parenthesis in screenshot title

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="insightconnect_integrations_validators",
-    version="2.43.1",
+    version="2.43.2",
     description="Validator tooling for InsightConnect integrations",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION

## Proposed Changes
The version bump validator was broken. This was undiscovered when initially merged because of a different issue preventing the validator from running at all. 

### Description

Describe the proposed changes:

  - 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

- [ ] Unit tests written for any new or updated code
- [ ] Version bumped within setup.py
- [ ] Changelog entry added
