### PR TITLE
Add support for extension_library and hub_tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ be on your way to contributing!
 
 ## Changelog
 
+* 2.44.3 - Add support for renamed 'hub_tags' sections to 'extension_library' in plugin.spec.yaml and workflow.spec.yaml files
 * 2.44.2 - Fixed (and tested) VersionBumpValidator on new plugin
 * 2.44.1 - Fixed VersionBumpValidator bug on new plugins
 * 2.44.0 - Update WorkflowTitleValidator to validate titles in `.icon` file

--- a/icon_validator/rules/plugin_validators/unapproved_keywords_validator.py
+++ b/icon_validator/rules/plugin_validators/unapproved_keywords_validator.py
@@ -35,7 +35,9 @@ class UnapprovedKeywordsValidator(KomandPluginValidator):
     @staticmethod
     def validate_keywords_exists(spec: KomandPluginSpec):
         try:
-            keywords = spec.spec_dictionary()["hub_tags"]["keywords"]
+            # Check for hub_tags (old) or extension_library (newer) for backwards-compatibility
+            ext_library_section = spec.spec_dictionary().get("hub_tags") or spec.spec_dictionary()["extension_library"]
+            keywords = ext_library_section["keywords"]
             if not keywords or not len(keywords):
                 raise ValidationException("Empty required field 'keywords' in key 'hub_tags'.")
         except KeyError:
@@ -55,4 +57,5 @@ class UnapprovedKeywordsValidator(KomandPluginValidator):
 
     def validate(self, spec: KomandPluginSpec):
         UnapprovedKeywordsValidator.validate_keywords_exists(spec)
-        UnapprovedKeywordsValidator.validate_keywords(spec.spec_dictionary()["hub_tags"]["keywords"])
+        ext_library_section = spec.spec_dictionary().get("hub_tags") or spec.spec_dictionary().get("extension_library")
+        UnapprovedKeywordsValidator.validate_keywords(ext_library_section["keywords"])

--- a/icon_validator/rules/plugin_validators/use_case_validator.py
+++ b/icon_validator/rules/plugin_validators/use_case_validator.py
@@ -25,7 +25,8 @@ class UseCaseValidator(KomandPluginValidator):
     @staticmethod
     def validate_use_case_exists(spec: KomandPluginSpec):
         try:
-            use_cases = spec.spec_dictionary()["hub_tags"]["use_cases"]
+            ext_library_section = spec.spec_dictionary().get("hub_tags") or spec.spec_dictionary().get("extension_library")
+            use_cases = ext_library_section["use_cases"]
             if not use_cases or not len(use_cases):
                 raise ValidationException("Empty required field 'use_cases' in key 'hub_tags'.")
         except KeyError:
@@ -63,5 +64,8 @@ class UseCaseValidator(KomandPluginValidator):
 
     def validate(self, spec: KomandPluginSpec):
         UseCaseValidator.validate_use_case_exists(spec)
-        UseCaseValidator.validate_use_cases(spec.spec_dictionary()["hub_tags"]["use_cases"])
-        UseCaseValidator.validate_use_case_in_keywords(spec.spec_dictionary()["hub_tags"].get("keywords"))
+
+        ext_library_section = spec.spec_dictionary().get("hub_tags") or spec.spec_dictionary().get("extension_library")
+
+        UseCaseValidator.validate_use_cases(ext_library_section["use_cases"])
+        UseCaseValidator.validate_use_case_in_keywords(ext_library_section.get("keywords"))

--- a/icon_validator/rules/workflow_validators/workflow_parameters_keyword_validator.py
+++ b/icon_validator/rules/workflow_validators/workflow_parameters_keyword_validator.py
@@ -34,7 +34,7 @@ class WorkflowParametersKeywordValidator(KomandPluginValidator):
     def validate(self, spec):
         if self.are_parameters_present_in_icon_file(spec):
             spec_dictionary = spec.spec_dictionary()
-            keywords = spec_dictionary.get("hub_tags", {}).get("keywords", [])
+            keywords = spec_dictionary.get("extension_library", {}).get("keywords", [])
             if not "parameters" in keywords:
                 raise ValidationException("The workflow uses parameters, however the parameters "
                                           "keyword is not present in workflow.spec.yaml keywords")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="insightconnect_integrations_validators",
-    version="2.44.2",
+    version="2.44.3",
     description="Validator tooling for InsightConnect integrations",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/unit_test/workflow_examples/Automated_Indicator_Enrichment/workflow.spec.yaml
+++ b/unit_test/workflow_examples/Automated_Indicator_Enrichment/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/bad_help_plugin_utilization_validator_bad_plugin_version/workflow.spec.yaml
+++ b/unit_test/workflow_examples/bad_help_plugin_utilization_validator_bad_plugin_version/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/change_log_tests/workflow.spec.yaml
+++ b/unit_test/workflow_examples/change_log_tests/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/description_tests/workflow_blank_description.spec.yaml
+++ b/unit_test/workflow_examples/description_tests/workflow_blank_description.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/description_tests/workflow_lower_case.spec.yaml
+++ b/unit_test/workflow_examples/description_tests/workflow_lower_case.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/description_tests/workflow_no_description.spec.yaml
+++ b/unit_test/workflow_examples/description_tests/workflow_no_description.spec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/description_tests/workflow_no_period.spec.yaml
+++ b/unit_test/workflow_examples/description_tests/workflow_no_period.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/description_tests/workflow_whitespace.spec.yaml
+++ b/unit_test/workflow_examples/description_tests/workflow_whitespace.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/description_validator_bad/workflow.spec.yaml
+++ b/unit_test/workflow_examples/description_validator_bad/workflow.spec.yaml
@@ -8,7 +8,7 @@ version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases:
   - threat_detection_and_response
   keywords:

--- a/unit_test/workflow_examples/description_validator_empty_description_in_icon/workflow.spec.yaml
+++ b/unit_test/workflow_examples/description_validator_empty_description_in_icon/workflow.spec.yaml
@@ -8,7 +8,7 @@ version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases:
   - threat_detection_and_response
   keywords:

--- a/unit_test/workflow_examples/description_validator_empty_use_case_bad/workflow.spec.yaml
+++ b/unit_test/workflow_examples/description_validator_empty_use_case_bad/workflow.spec.yaml
@@ -8,7 +8,7 @@ version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: []
   keywords:
   - chat

--- a/unit_test/workflow_examples/description_validator_good/workflow.spec.yaml
+++ b/unit_test/workflow_examples/description_validator_good/workflow.spec.yaml
@@ -8,7 +8,7 @@ version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases:
   - threat_detection_and_response
   keywords:

--- a/unit_test/workflow_examples/description_validator_good_keywords/workflow.spec.yaml
+++ b/unit_test/workflow_examples/description_validator_good_keywords/workflow.spec.yaml
@@ -8,7 +8,7 @@ version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases:
   - threat_detection_and_response
   keywords:

--- a/unit_test/workflow_examples/description_validator_keywords_from_use_case_list_bad/workflow.spec.yaml
+++ b/unit_test/workflow_examples/description_validator_keywords_from_use_case_list_bad/workflow.spec.yaml
@@ -8,7 +8,7 @@ version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases:
   - threat_detection_and_response
   keywords:

--- a/unit_test/workflow_examples/description_validator_use_case_not_from_list_bad/workflow.spec.yaml
+++ b/unit_test/workflow_examples/description_validator_use_case_not_from_list_bad/workflow.spec.yaml
@@ -8,7 +8,7 @@ version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases:
   - threat_detection_and_response
   - user

--- a/unit_test/workflow_examples/encoding_tests/workflow_bad_encoding.spec.yaml
+++ b/unit_test/workflow_examples/encoding_tests/workflow_bad_encoding.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [“vulnerability_management”,””alerting_and_notifications”,”asset_inventory”]
   keywords: [“slack”, “chat”, “active_directory”]
   features: []

--- a/unit_test/workflow_examples/encoding_tests/workflow_good_encoding.spec.yaml
+++ b/unit_test/workflow_examples/encoding_tests/workflow_good_encoding.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: ["vulnerability_management","alerting_and_notifications","asset_inventory"]
   keywords: ["slack", "chat", "active_directory"]
   features: []

--- a/unit_test/workflow_examples/extension_tests/workflow_extension_not_workflow.spec.yaml
+++ b/unit_test/workflow_examples/extension_tests/workflow_extension_not_workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/files_tests/workflow.spec.yaml
+++ b/unit_test/workflow_examples/files_tests/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/help_plugin_utilization_validator_no_plugin_in_help/workflow.spec.yaml
+++ b/unit_test/workflow_examples/help_plugin_utilization_validator_no_plugin_in_help/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [threat_detection_and_response]
   keywords: [slack, chat, chatops, work_from_home, cloud_enabled]
   features: []

--- a/unit_test/workflow_examples/help_tests/workflow.spec.yaml
+++ b/unit_test/workflow_examples/help_tests/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/icon_file_tests/workflow.spec_bad_icon_file.yaml
+++ b/unit_test/workflow_examples/icon_file_tests/workflow.spec_bad_icon_file.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/icon_filename_tests/workflow.spec.yaml
+++ b/unit_test/workflow_examples/icon_filename_tests/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/name_tests/workflow_bad_name.spec.yaml
+++ b/unit_test/workflow_examples/name_tests/workflow_bad_name.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/parameters_bad/workflow.spec.yaml
+++ b/unit_test/workflow_examples/parameters_bad/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 2.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/parameters_good/workflow.spec.yaml
+++ b/unit_test/workflow_examples/parameters_good/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 2.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip, parameters]
   features: []

--- a/unit_test/workflow_examples/plugin_utilization_tests/workflow.spec_bad_utilization.yaml
+++ b/unit_test/workflow_examples/plugin_utilization_tests/workflow.spec_bad_utilization.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/png_hash_tests/workflow.spec.yaml
+++ b/unit_test/workflow_examples/png_hash_tests/workflow.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/profanity_tests/workflow_profanity.spec.yaml
+++ b/unit_test/workflow_examples/profanity_tests/workflow_profanity.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: ass
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/python_plugin_used/workflow.spec.yaml
+++ b/unit_test/workflow_examples/python_plugin_used/workflow.spec.yaml
@@ -8,7 +8,7 @@ version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases:
   - threat_detection_and_response
   keywords:

--- a/unit_test/workflow_examples/screenshot_tests/workflow_bad_title.spec.yaml
+++ b/unit_test/workflow_examples/screenshot_tests/workflow_bad_title.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/screenshot_tests/workflow_brackets_in_title.spec.yaml
+++ b/unit_test/workflow_examples/screenshot_tests/workflow_brackets_in_title.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/screenshot_tests/workflow_missing_key.spec.yaml
+++ b/unit_test/workflow_examples/screenshot_tests/workflow_missing_key.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/screenshot_tests/workflow_missing_name.spec.yaml
+++ b/unit_test/workflow_examples/screenshot_tests/workflow_missing_name.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/screenshot_tests/workflow_missing_title.spec.yaml
+++ b/unit_test/workflow_examples/screenshot_tests/workflow_missing_title.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/support_tests/workflow_no_supporter.spec.yaml
+++ b/unit_test/workflow_examples/support_tests/workflow_no_supporter.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support:
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/title_tests/numeric_in_title.yaml
+++ b/unit_test/workflow_examples/title_tests/numeric_in_title.yaml
@@ -7,7 +7,7 @@ version: 0.1.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/title_tests/workflow_bad_caps.spec.yaml
+++ b/unit_test/workflow_examples/title_tests/workflow_bad_caps.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/title_tests/workflow_ends_with_period.spec.yaml
+++ b/unit_test/workflow_examples/title_tests/workflow_ends_with_period.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/title_tests/workflow_no_title.spec.yaml
+++ b/unit_test/workflow_examples/title_tests/workflow_no_title.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/vendor_tests/workflow_no_vendor.spec.yaml
+++ b/unit_test/workflow_examples/vendor_tests/workflow_no_vendor.spec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0
 vendor:
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []

--- a/unit_test/workflow_examples/version_tests/workflow_version_too_low.spec.yaml
+++ b/unit_test/workflow_examples/version_tests/workflow_version_too_low.spec.yaml
@@ -7,7 +7,7 @@ version: 0.1.0
 vendor: rapid7
 support: rapid7
 status: []
-hub_tags:
+extension_library:
   use_cases: [alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]
   features: []


### PR DESCRIPTION

## Proposed Changes

### Description

Describe the proposed changes:

  - Add backwards-compatible support for changing hub_tags field in workflow.spec.yaml and plugin.spec.yaml files to extension_library

## PR Requirements

Developers, verify you have completed the following items by checking them off:

- [x] Unit tests written for any new or updated code
- [x] Version bumped within setup.py
- [x] Changelog entry added
