### PR TITLE
Update Version Validator to check v2 api Call

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ be on your way to contributing!
 
 ## Changelog
 
+* 2.46.2 - Update version validator to check v2 api call
 * 2.46.1 - Add null variable check to example input validator
 * 2.46.0 - Add new help.md validator to ensure there are key features, links, and examples
 * 2.45.0 - Separated UseCaseValidator for workflows as plugins and workflows now have different usecase tags

--- a/icon_validator/rules/plugin_validators/version_validator.py
+++ b/icon_validator/rules/plugin_validators/version_validator.py
@@ -39,7 +39,12 @@ class VersionValidator(KomandPluginValidator):
             timeout=3
         )
         if response.status_code == 404:
-            return
+            response = requests.get(
+                url=f"https://extensions-api.rapid7.com/v2/public/extensions/{plugin_name}",
+                timeout=3
+            )
+            if response.status_code == 404:
+                return
 
         if response.json()["version"] == spec.spec_dictionary()["version"]:
             raise ValidationException("The plugin has been modified without a version change. Please update the semver in plugin.spec.yaml, regenerate, and create a changelog entry under Version History in help.md")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="insightconnect_integrations_validators",
-    version="2.46.1",
+    version="2.46.2",
     description="Validator tooling for InsightConnect integrations",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="insightconnect_integrations_validators",
-    version="2.46.2",
+    version="2.46.3",
     description="Validator tooling for InsightConnect integrations",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/unit_test/test_validate_plugin.py
+++ b/unit_test/test_validate_plugin.py
@@ -115,7 +115,7 @@ class TestPluginValidate(unittest.TestCase):
     def test_version_validator_should_faile_when_version_same_in_api(self):
         # example workflow in plugin_examples directory. Run tests with these files
         version = requests.get(
-            url=f"https://extensions-api.rapid7.com/v1/public/extensions/active_directory_ldap",
+            url=f"https://extensions-api.rapid7.com/v2/public/extensions/active_directory_ldap",
             timeout=3
         ).json()["version"]
 


### PR DESCRIPTION

## Proposed Changes

### Description

The test for version validator was failing because it was calling "https://extensions-api.rapid7.com/v1/public/publishers/rapid7/extensions/active-directory-ldap" which resulted in a 404, because v2 was needed. Updated the test and put a check in the validator to try v2 as well as v1.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

- [x] Unit tests written for any new or updated code
- [x] Version bumped within setup.py
- [x] Changelog entry added
