### PR TITLE
[SOAR-14231] Add new help validator for custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ be on your way to contributing!
 
 ## Changelog
 
+* 2.47.4 - New help validator to handle `Custom Types` title
 * 2.47.3 - Fix HelpInputOutputValidator when output in plugin.spec.yaml not contain an example field | Fix validation when example contains list in object in HelpExampleValidator
 * 2.47.2 - Allow hyphens in WorkflowTitleValidator
 * 2.47.1 - Fix plugin spec properties validator for tasks

--- a/icon_validator/rules/plugin_validators/help_validator.py
+++ b/icon_validator/rules/plugin_validators/help_validator.py
@@ -19,7 +19,7 @@ class HelpValidator(KomandPluginValidator):
         "## Troubleshooting",
         "# Version History",
         "# Links",
-        "## References"
+        "## References",
     ]
 
     CUSTOM_TYPES_HEADERS_LIST = [
@@ -127,13 +127,15 @@ class HelpValidator(KomandPluginValidator):
 
         :param help_str: The help.md as a raw string
         """
-        counter = 0
+        missing_header = []
         help_headers_errors = []
         for header in HelpValidator.CUSTOM_TYPES_HEADERS_LIST:
             if header not in help_str:
-                counter = counter + 1
-            if counter == 2:
-                help_headers_errors.append(f"Help section is missing header: {header}")
+                missing_header.append(header)
+            if len(missing_header) == 2:
+                help_headers_errors.append(
+                    f"Help section is missing either header: {[header for header in missing_header]}"
+                )
 
         if help_headers_errors:
             raise ValidationException("\n".join(help_headers_errors))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="insightconnect_integrations_validators",
-    version="2.47.3",
+    version="2.47.4",
     description="Validator tooling for InsightConnect integrations",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION

## Proposed Changes
Add a new help validator to check for either `Custom Types` or `Custom Output Types` to handle difference between help.md's generated by both `icon-plugin` & `insight-plugin`
### Description

Describe the proposed changes:

  - 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

- [ ] Unit tests written for any new or updated code
- [x] Version bumped within setup.py
- [x] Changelog entry added
