### PR TITLE
SOAR-16046: correctly validate cloud plugin with new SDK image

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ be on your way to contributing!
 
 ## Changelog
 
+* 2.47.9 - `DockerfileParentValidator` | `CloudReadyValidator` - update to support cloud plugins and SDK image with specified `--platform` flag. 
 * 2.47.8 - `DockerfileParentValidator` | `RuntimeValidator` - update supported SDK images | Updated `GitPython` to version 3.1.37
 * 2.47.7 - `ConfidentialValidator` - Changed email violation to a warning
 * 2.47.6 - Updated `GitPython` to version 3.1.32

--- a/icon_validator/rules/plugin_validators/cloud_ready_validator.py
+++ b/icon_validator/rules/plugin_validators/cloud_ready_validator.py
@@ -18,7 +18,7 @@ class CloudReadyValidator(KomandPluginValidator):
     @staticmethod
     def validate_python_version_in_dockerfile(dockerfile: str):
         docker_str = dockerfile.replace(" --platform=linux/amd64 ", " ")  # if user has specified '--platform' remove
-        if not re.compile(r"FROM rapid7/insightconnect-python-3(-slim)?-plugin:(([0-9][0-9]+)|[4-9])")\
+        if not re.compile(r"FROM rapid7/insightconnect-python-3(-slim)?-plugin:(([0-9][0-9]+)|[4-9]|latest)")\
                 .match(docker_str):
             raise ValidationException(
                 "The python runtime must be in 5+ version to be Cloud Ready."

--- a/icon_validator/rules/plugin_validators/cloud_ready_validator.py
+++ b/icon_validator/rules/plugin_validators/cloud_ready_validator.py
@@ -17,10 +17,11 @@ class CloudReadyValidator(KomandPluginValidator):
 
     @staticmethod
     def validate_python_version_in_dockerfile(dockerfile: str):
-        if not re.compile(r"FROM rapid7/insightconnect-python-3-38(-slim)?-plugin:(([0-9][0-9]+)|[4-9])")\
-                .match(dockerfile):
+        docker_str = dockerfile.replace(" --platform=linux/amd64 ", " ")  # if user has specified '--platform' remove
+        if not re.compile(r"FROM rapid7/insightconnect-python-3(-slim)?-plugin:(([0-9][0-9]+)|[4-9])")\
+                .match(docker_str):
             raise ValidationException(
-                "The python runtime must be in 4+ version to be Cloud Ready."
+                "The python runtime must be in 5+ version to be Cloud Ready."
                 "Update Dockerfile and try again."
             )
 

--- a/icon_validator/rules/plugin_validators/dockerfile_parent_validator.py
+++ b/icon_validator/rules/plugin_validators/dockerfile_parent_validator.py
@@ -18,7 +18,7 @@ class DockerfileParentValidator(KomandPluginValidator):
         root_spec_found = False
         for line in spec.raw_dockerfile():
             if line.startswith("FROM"):
-                parent = line.replace("FROM", "").strip()
+                parent = line.replace("FROM", "").replace("--platform=linux/amd64", "").strip()
                 parts = parent.split(":")
                 image = parts[0].strip()
                 if image == "komand/python-plugin":

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="insightconnect_integrations_validators",
-    version="2.47.8",
+    version="2.47.9",
     description="Validator tooling for InsightConnect integrations",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/unit_test/plugin_examples/good_plugin_cloud_ready/Dockerfile
+++ b/unit_test/plugin_examples/good_plugin_cloud_ready/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-slim-plugin:4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5
 # Refer to the following documentation for available SDK parent images: https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide
 
 LABEL organization=komand

--- a/unit_test/test_validate_plugin/test_validate_plugin.py
+++ b/unit_test/test_validate_plugin/test_validate_plugin.py
@@ -1,5 +1,6 @@
 import unittest
 from icon_validator.validate import validate
+from icon_validator.exceptions import ValidationException
 from icon_plugin_spec.plugin_spec import KomandPluginSpec
 
 # Import plugin validators to pass to tests
@@ -433,6 +434,16 @@ class TestPluginValidate(unittest.TestCase):
         file_to_test = "plugin.spec.yaml"
         result = validate(directory_to_test, file_to_test, False, True, [CloudReadyValidator()])
         self.assertEqual(result, 0)
+
+    def test_cloud_ready_validator_should_success_latest_version_string(self):
+        # Test when a cloud ready plugin specifies ':latest' as SDK image regex still validates
+        docker_file = directory_to_test = "plugin_examples/good_plugin_cloud_ready/Dockerfile"
+        with open(docker_file, "r") as file:
+            docker_str = file.read().replace(":5", ":latest")
+            try:
+                CloudReadyValidator().validate_python_version_in_dockerfile(docker_str)
+            except ValidationException:
+                raise Exception("We do not expect the supplied docker string to fail. We should support ':latest'")
 
     def test_acronym_validator_should_success(self):
         # example workflow in plugin_examples directory. Run tests with these files


### PR DESCRIPTION
## Proposed Changes
[SOAR-16046](https://issues.corp.rapid7.com/browse/SOAR-16046) : Bump version to correctly validate the docker image for cloud enabled plugins

### Description
- Missed validator code that runs for cloud enabled plugins to also validate against the new SDK image. Updated the regex to no longer need the `38` part. 
- When using [refresh command](https://github.com/rapid7/insight-plugin/blob/master/insight_plugin/templates/Dockerfile.jinja) the platform flag gets added by default. Don't include this as part of the validation.

### Testing
- Installed validators using `pip install -e .` so I can dynamically swap between dev and master versions. 
- Updated okta plugin locally Dockerfile manually to include platform flag and new SDK image. Validates on dev branch, fails as expected on master. 
- Unit tests updated and passing. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

- [X] Unit tests written for any new or updated code
- [X] Version bumped within setup.py
- [X] Changelog entry added

### Note
- I have added `do not merge` label as I want to merge and release alongside [SOAR-16063](https://issues.corp.rapid7.com/browse/SOAR-16063) (PR pending..)
