### PR TITLE
SOAR-16063: validation on connection version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ be on your way to contributing!
 
 ## Changelog
 
-* 2.47.9 - `DockerfileParentValidator` | `CloudReadyValidator` - update to support cloud plugins and SDK image with specified `--platform` flag. 
+* 2.47.9 - `DockerfileParentValidator` | `CloudReadyValidator` - update to support cloud plugins and SDK image with specified `--platform` flag | `VersionBumpValidator` - add validation for connection versions.
 * 2.47.8 - `DockerfileParentValidator` | `RuntimeValidator` - update supported SDK images | Updated `GitPython` to version 3.1.37
 * 2.47.7 - `ConfidentialValidator` - Changed email violation to a warning
 * 2.47.6 - Updated `GitPython` to version 3.1.32

--- a/icon_validator/exceptions.py
+++ b/icon_validator/exceptions.py
@@ -1,3 +1,8 @@
+NO_LOCAL_CON_VERSION = "Connection detail specified in plugin.spec.yaml but no connection version has been specified."
+NO_CON_VERSION_CHANGE = "Connection details have changed but no version bump has occurred."
+INVALID_CON_VERSION_CHANGE = "Connection details have not changed but the connection version was bumped."
+INCORRECT_CON_VERSION_CHANGE = "Connection version has been bumped incorrectly."
+
 class ValidationException(Exception):
     """
     An exception which indicates that a validator has failed

--- a/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.bad.connection.change.yaml
+++ b/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.bad.connection.change.yaml
@@ -5,7 +5,7 @@ name: microsoft_office365_email
 title: Microsoft Office 365 Email
 description: The Microsoft Office 365 email plugin enables phishing analysis and email management. The plugin includes the ability to manage and remediate suspicious email
 version: 6.0.0
-connection_version: 5
+connection_version: 6
 vendor: rapid7
 support: rapid7
 status: []
@@ -46,7 +46,7 @@ types:
     id:
       type: string
       title: ID
-      required: false
+      required: True
     sender:
       type: string
       required: false
@@ -312,6 +312,47 @@ triggers:
         required: false
         description: Email
 actions:
+  get_email_from_user:
+    title: Get Email from User
+    description: Get a list of emails from a user's mailbox matching search terms
+    input:
+      mailbox_id:
+        title: Mailbox ID
+        type: string
+        description: Target user to retrieve email from
+        example: user@example.com
+        required: true
+      max_number_to_return:
+        title: Max Number to Return
+        type: integer
+        default: 250
+        description: Maximum number of emails to return. Max limit is 250 (default)
+        example: 250
+        required: false
+      from_contains:
+        title: From
+        type: string
+        description: From address contains this (can be full e-mail address or just a domain) e.g. user@example.com or example.com
+        example: example.com
+        required: false
+      subject_contains:
+        title: Subject
+        type: string
+        description: Subject contains this word or phrase
+        example: Free
+        required: false
+      body_contains:
+        title: Body
+        type: string
+        description: Body contains this word or phrase
+        example: Click here
+        required: false
+    output:
+      email_list:
+        title: Email List
+        type: '[]icon_email'
+        description: List of emails
+        required: false
   delete_email:
     title: Delete Email
     description: Delete an email by ID

--- a/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.bad.new.connection.version.yaml
+++ b/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.bad.new.connection.version.yaml
@@ -5,7 +5,7 @@ name: microsoft_office365_email
 title: Microsoft Office 365 Email
 description: The Microsoft Office 365 email plugin enables phishing analysis and email management. The plugin includes the ability to manage and remediate suspicious email
 version: 6.0.0
-connection_version: 5
+connection_version: 7
 vendor: rapid7
 support: rapid7
 status: []
@@ -212,7 +212,7 @@ connection:
     type: string
     required: true
     example: b12abc12-abcd-abcd-abcd-3ac2dz8e9z2g
-  app_secret:
+  app_secret_change:
     title: App Secret
     description: The secret of the registered app that obtained the refresh token
     type: credential_secret_key
@@ -312,6 +312,47 @@ triggers:
         required: false
         description: Email
 actions:
+  get_email_from_user:
+    title: Get Email from User
+    description: Get a list of emails from a user's mailbox matching search terms
+    input:
+      mailbox_id:
+        title: Mailbox ID
+        type: string
+        description: Target user to retrieve email from
+        example: user@example.com
+        required: true
+      max_number_to_return:
+        title: Max Number to Return
+        type: integer
+        default: 250
+        description: Maximum number of emails to return. Max limit is 250 (default)
+        example: 250
+        required: false
+      from_contains:
+        title: From
+        type: string
+        description: From address contains this (can be full e-mail address or just a domain) e.g. user@example.com or example.com
+        example: example.com
+        required: false
+      subject_contains:
+        title: Subject
+        type: string
+        description: Subject contains this word or phrase
+        example: Free
+        required: false
+      body_contains:
+        title: Body
+        type: string
+        description: Body contains this word or phrase
+        example: Click here
+        required: false
+    output:
+      email_list:
+        title: Email List
+        type: '[]icon_email'
+        description: List of emails
+        required: false
   delete_email:
     title: Delete Email
     description: Delete an email by ID

--- a/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.bad.new.connection.yaml
+++ b/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.bad.new.connection.yaml
@@ -212,7 +212,7 @@ connection:
     type: string
     required: true
     example: b12abc12-abcd-abcd-abcd-3ac2dz8e9z2g
-  app_secret:
+  app_secret_change:
     title: App Secret
     description: The secret of the registered app that obtained the refresh token
     type: credential_secret_key
@@ -312,6 +312,47 @@ triggers:
         required: false
         description: Email
 actions:
+  get_email_from_user:
+    title: Get Email from User
+    description: Get a list of emails from a user's mailbox matching search terms
+    input:
+      mailbox_id:
+        title: Mailbox ID
+        type: string
+        description: Target user to retrieve email from
+        example: user@example.com
+        required: true
+      max_number_to_return:
+        title: Max Number to Return
+        type: integer
+        default: 250
+        description: Maximum number of emails to return. Max limit is 250 (default)
+        example: 250
+        required: false
+      from_contains:
+        title: From
+        type: string
+        description: From address contains this (can be full e-mail address or just a domain) e.g. user@example.com or example.com
+        example: example.com
+        required: false
+      subject_contains:
+        title: Subject
+        type: string
+        description: Subject contains this word or phrase
+        example: Free
+        required: false
+      body_contains:
+        title: Body
+        type: string
+        description: Body contains this word or phrase
+        example: Click here
+        required: false
+    output:
+      email_list:
+        title: Email List
+        type: '[]icon_email'
+        description: List of emails
+        required: false
   delete_email:
     title: Delete Email
     description: Delete an email by ID

--- a/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.good.new.connection.yaml
+++ b/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.good.new.connection.yaml
@@ -5,7 +5,7 @@ name: microsoft_office365_email
 title: Microsoft Office 365 Email
 description: The Microsoft Office 365 email plugin enables phishing analysis and email management. The plugin includes the ability to manage and remediate suspicious email
 version: 6.0.0
-connection_version: 5
+connection_version: 6
 vendor: rapid7
 support: rapid7
 status: []
@@ -212,7 +212,7 @@ connection:
     type: string
     required: true
     example: b12abc12-abcd-abcd-abcd-3ac2dz8e9z2g
-  app_secret:
+  app_secret_change:
     title: App Secret
     description: The secret of the registered app that obtained the refresh token
     type: credential_secret_key
@@ -312,6 +312,47 @@ triggers:
         required: false
         description: Email
 actions:
+  get_email_from_user:
+    title: Get Email from User
+    description: Get a list of emails from a user's mailbox matching search terms
+    input:
+      mailbox_id:
+        title: Mailbox ID
+        type: string
+        description: Target user to retrieve email from
+        example: user@example.com
+        required: true
+      max_number_to_return:
+        title: Max Number to Return
+        type: integer
+        default: 250
+        description: Maximum number of emails to return. Max limit is 250 (default)
+        example: 250
+        required: false
+      from_contains:
+        title: From
+        type: string
+        description: From address contains this (can be full e-mail address or just a domain) e.g. user@example.com or example.com
+        example: example.com
+        required: false
+      subject_contains:
+        title: Subject
+        type: string
+        description: Subject contains this word or phrase
+        example: Free
+        required: false
+      body_contains:
+        title: Body
+        type: string
+        description: Body contains this word or phrase
+        example: Click here
+        required: false
+    output:
+      email_list:
+        title: Email List
+        type: '[]icon_email'
+        description: List of emails
+        required: false
   delete_email:
     title: Delete Email
     description: Delete an email by ID

--- a/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.remote.yaml
+++ b/unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.remote.yaml
@@ -5,6 +5,7 @@ name: microsoft_office365_email
 title: Microsoft Office 365 Email
 description: The Microsoft Office 365 email plugin enables phishing analysis and email management. The plugin includes the ability to manage and remediate suspicious email
 version: 5.0.5
+connection_version: 5
 vendor: rapid7
 support: rapid7
 status: []


### PR DESCRIPTION
## Proposed Changes
[SOAR-16063](https://issues.corp.rapid7.com/browse/SOAR-16063) : Update validators to validate connection version

### Description
New validation logic added that will perform various checks on the connection_version specified in the plugin.spec.yaml file. I have covered the following scenarios as mentioned on the ticket and tested this by adding new unit tests and updating existing unit tests that were raising these new validation errors. 

1. Plugin is being released with connection schema but no connection version specified. 
2. Plugin is being released with a change in the connection schema and the connection version not bumped.
3. Plugin major release *but* with no connection schema -> connection version does not need to be bumped.
4. If we are bumping the connection version this should be "old connection" + 1

## Describe the proposed changes:
Majority of 'code' changes are new test spec files. I was able to piggyback alongside the version bump validator as it already has logic that forces a plugin version bump when connection is changed.: 

```
def validate....
   .....
   self.validate_connections(remote_spec, local_spec)
```

- `icon_validator/exceptions.py`: new exception messages, defined here to update in one place to take effect in unit tests/validation logic.
- `icon_validator/rules/plugin_validators/version_bump_validator.py`: new validation logic and small tidy up of duplicate code. 
- `unit_test/test_validate_plugin/test_validate_plugin.py`: new unit test added / tidy up for unused var warning. 


## Help for reviewers:
When no local spec file is passed to the unit test it defaults to use: `unit_test/plugin_examples/plugin_major_version_bump_all/plugin.spec.remote.yaml`.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

- [X] Unit tests written for any new or updated code
- [X] Version bumped within setup.py <- bumped in #173 
- [ ] Changelog entry added <- will add second commit after #173 is merged and rebased to pull changes.
